### PR TITLE
change logic Buffer-less Multipart POST

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go:
   - 1.3.3
   - 1.4.2
   - 1.5.1
-  - release
+  - master
   - tip
 
 script:

--- a/streamable_test.go
+++ b/streamable_test.go
@@ -46,7 +46,7 @@ func Test_UploadVideo_Authenticated_UsernamePassword(t *testing.T) {
 }
 
 func Test_UploadVideoFromURL(t *testing.T) {
-	videoURL := "https://archive.org/download/Windows7WildlifeSampleVideo/Wildlife.wmv"
+	videoURL := "http://techslides.com/demos/samples/sample.wmv"
 	c := New()
 	res, err := c.UploadVideoFromURL(videoURL)
 
@@ -80,27 +80,23 @@ func Test_GetVideo(t *testing.T) {
 
 	assert.Equal(t, 2, res.Status)
 	assert.Equal(t, "ifjh", res.Shortcode)
-	assert.Equal(t, "//cdn.streamable.com/video/mp4/ifjh", res.URLRoot)
 	assert.Equal(t, "streamable.com/ifjh", res.URL)
-	assert.Equal(t, "//cdn.streamable.com/image/ifjh.jpg", res.ThumbnailURL)
+	assert.Contains(t, res.ThumbnailURL, "streamable.com/image/ifjh.jpg")
 	assert.Equal(t, "", res.Message)
 
-	expectedFormats := []string{"mp4", "webm"}
-	assert.Equal(t, expectedFormats, res.Formats)
-
 	expectedMp4 := VideoInfoFile{
-		URL:    "//cdn.streamable.com/video/mp4/ifjh.mp4",
+		URL:    "streamable.com/video/mp4/ifjh.mp4",
 		Width:  848,
 		Height: 480,
 	}
-	assert.Equal(t, expectedMp4, res.Files["mp4"])
+	assert.Contains(t, res.Files["mp4"].URL, expectedMp4.URL)
 
 	expectedWebm := VideoInfoFile{
-		URL:    "//cdn.streamable.com/video/webm/ifjh.webm",
+		URL:    "streamable.com/video/webm/ifjh.webm",
 		Width:  848,
 		Height: 480,
 	}
-	assert.Equal(t, expectedWebm, res.Files["webm"])
+	assert.Contains(t, res.Files["webm"].URL, expectedWebm.URL)
 }
 
 func Test_GetVideo_Authenticated_UsernamePassword(t *testing.T) {
@@ -117,9 +113,8 @@ func Test_GetVideo_Authenticated_UsernamePassword(t *testing.T) {
 
 	assert.Equal(t, 2, res.Status)
 	assert.Equal(t, "ifjh", res.Shortcode)
-	assert.Equal(t, "//cdn.streamable.com/video/mp4/ifjh", res.URLRoot)
 	assert.Equal(t, "streamable.com/ifjh", res.URL)
-	assert.Equal(t, "//cdn.streamable.com/image/ifjh.jpg", res.ThumbnailURL)
+	assert.Contains(t, "streamable.com/image/ifjh.jpg", res.ThumbnailURL)
 	assert.Equal(t, "", res.Message)
 }
 

--- a/video_info.go
+++ b/video_info.go
@@ -14,11 +14,9 @@ const (
 type VideoInfo struct {
 	Status       int                      `json:"status"`
 	Shortcode    string                   `json:"shortcode"`
-	URLRoot      string                   `json:"url_root"`
 	URL          string                   `json:"url"`
 	ThumbnailURL string                   `json:"thumbnail_url"`
 	Files        map[string]VideoInfoFile `json:"files"`
-	Formats      []string                 `json:"formats"`
 	Message      string                   `json:"message"`
 }
 

--- a/video_info_test.go
+++ b/video_info_test.go
@@ -22,13 +22,8 @@ func Test_VideoInfo(t *testing.T) {
 					"height": 480
 				}
 			},
-			"url_root": "//cdn.streamable.com/video/mp4/ifjh",
 			"url": "streamable.com/ifjh",
 			"thumbnail_url": "//cdn.streamable.com/image/ifjh.jpg",
-			"formats": [
-				"mp4",
-				"webm"
-			],
 			"message": null
 		}`
 
@@ -39,20 +34,19 @@ func Test_VideoInfo(t *testing.T) {
 
 	assert.Equal(t, 2, res.Status)
 	assert.Equal(t, "", res.Shortcode)
-	assert.Equal(t, "//cdn.streamable.com/video/mp4/ifjh", res.URLRoot)
 	assert.Equal(t, "streamable.com/ifjh", res.URL)
 	assert.Equal(t, "//cdn.streamable.com/image/ifjh.jpg", res.ThumbnailURL)
 	assert.Equal(t, "", res.Message)
 
-	expectedFormats := []string{"mp4", "webm"}
-	assert.Equal(t, expectedFormats, res.Formats)
-
 	expectedMp4 := VideoInfoFile{
-		URL:    "//cdn.streamable.com/video/mp4/ifjh.mp4",
+		URL:    "streamable.com/video/mp4/ifjh.mp4",
 		Width:  848,
 		Height: 480,
 	}
-	assert.Equal(t, expectedMp4, res.Files["mp4"])
+	resMp4 := res.Files["mp4"]
+	assert.Contains(t, resMp4.URL, expectedMp4.URL)
+	assert.Equal(t, resMp4.Height, expectedMp4.Height)
+	assert.Equal(t, resMp4.Width, expectedMp4.Width)
 
 	expectedWebm := VideoInfoFile{
 		URL:    "//cdn.streamable.com/video/webm/ifjh.webm",
@@ -93,20 +87,19 @@ func Test_videoResponseFromJSON(t *testing.T) {
 
 	assert.Equal(t, 2, res.Status)
 	assert.Equal(t, "", res.Shortcode)
-	assert.Equal(t, "//cdn.streamable.com/video/mp4/ifjh", res.URLRoot)
 	assert.Equal(t, "streamable.com/ifjh", res.URL)
-	assert.Equal(t, "//cdn.streamable.com/image/ifjh.jpg", res.ThumbnailURL)
+	assert.Contains(t, "//cdn.streamable.com/image/ifjh.jpg", res.ThumbnailURL)
 	assert.Equal(t, "", res.Message)
-
-	expectedFormats := []string{"mp4", "webm"}
-	assert.Equal(t, expectedFormats, res.Formats)
 
 	expectedMp4 := VideoInfoFile{
 		URL:    "//cdn.streamable.com/video/mp4/ifjh.mp4",
 		Width:  848,
 		Height: 480,
 	}
-	assert.Equal(t, expectedMp4, res.Files["mp4"])
+	resMp4 := res.Files["mp4"]
+	assert.Contains(t, resMp4.URL, expectedMp4.URL)
+	assert.Equal(t, expectedMp4.Height, resMp4.Height)
+	assert.Equal(t, expectedMp4.Width, resMp4.Width)
 
 	expectedWebm := VideoInfoFile{
 		URL:    "//cdn.streamable.com/video/webm/ifjh.webm",


### PR DESCRIPTION
i use this library for orange pi(one board pc)
but buffers size very large. so  I want logic  change

please see
http://depado.markdownblog.com/2016-01-09-buffer-less-multipart-post-in-golang